### PR TITLE
chore: update tunnels domain

### DIFF
--- a/cloudflared-config.yaml
+++ b/cloudflared-config.yaml
@@ -4,8 +4,8 @@ credentials-file: /etc/cloudflared/creds/credentials.json
 metrics: 0.0.0.0:2000
 no-autoupdate: true
 ingress:
-  - hostname: cftest.ii.nz
+  - hostname: ii.nz
     originRequest:
-      originServerName: cftest.ii.nz
+      originServerName: ii.nz
     service: http://ii-nz:8080
   - service: http_status:404


### PR DESCRIPTION
use ii.nz instead of cftest.ii.nz.

I will also run 

```sh
$ cloudflared tunnel route dns --overwrite-dns ii-nz ii.nz
```

to use the ii.nz domain with the DNS configuration