### PR TITLE
sort blog posts by date, descending

### DIFF
--- a/themes/ii/layouts/post/list.html
+++ b/themes/ii/layouts/post/list.html
@@ -1,0 +1,25 @@
+{{ define "main" }}
+
+<div class="content center-column">
+  <h1 class="section-title">{{ .Title }}</h1>
+
+  {{ .Content | emojify }}
+  <ul class="post-list">
+  {{ range .Pages.ByDate.Reverse  }}
+    <li class="post-list__item">
+      <a href="{{ .RelPermalink }}" class="post-title">{{ .Title }}</a>
+      <div class="post-metadata">
+        <span class="divider">//</span>
+      {{ range .Param "author" }}
+      <a class="post-author" href={{(path.Join "/team" (replace (lower .) " " "-"))}}>
+        {{ . }}
+      </a>
+      {{ end }}
+        <span class="divider">//</span>
+      <span class='post-date'>{{ .Date.Format ( .Site.Params.dateformat | default "Jan 2, 2006") }}</span>
+      </div>
+    </li>
+  {{ end }}
+  </ul>
+</div>
+{{ end }}


### PR DESCRIPTION
this adds an explicit list layout to our posts and then orders them by date, descending.  This order looks for the `date` field in the frontmatter to determine where in the list it appears, with newest posts up top.